### PR TITLE
add base api plugins subscribers and views

### DIFF
--- a/profiles/base.cfg
+++ b/profiles/base.cfg
@@ -93,7 +93,7 @@ update_after = false
 auth_file = ${buildout:directory}/auth.ini
 exc_logger = 1
 journal = 1
-plugins = audit,audit.inspection
+plugins = api,audit,audit.inspection
 
 [openprocurement.bot.risk_indicators.yaml]
 <= config-from-template


### PR DESCRIPTION
Вот тут подключаются subscribers, которые добавляют, например, параметры авторизации в контекст логов https://github.com/ProzorroUKR/openprocurement.api/blob/master/src/openprocurement/api/includeme.py#L8
Ну и остальное тоже вроде не помешает. Так-то думал оно и раньше работало, но нит.